### PR TITLE
고객관리 <- 고객 생성 기능 구현

### DIFF
--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/data/datasource/CustomerDataSource.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/data/datasource/CustomerDataSource.kt
@@ -1,0 +1,34 @@
+package com.dkproject.regularcustomermanagement.data.datasource
+
+import com.dkproject.regularcustomermanagement.data.dao.CustomerDao
+import com.dkproject.regularcustomermanagement.data.model.CustomerEntity
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+interface CustomerDataSource {
+    fun getAllCustomers(): Flow<List<CustomerEntity>>
+    suspend fun addCustomer(customerEntity: CustomerEntity)
+    suspend fun updateCustomer(customerEntity: CustomerEntity)
+    suspend fun deleteCustomer(customerEntity: CustomerEntity)
+}
+
+class CustomerDataSourceImpl @Inject constructor(
+    private val customerDao: CustomerDao
+): CustomerDataSource {
+    override fun getAllCustomers(): Flow<List<CustomerEntity>> {
+        return customerDao.getAllCustomers()
+    }
+
+    override suspend fun addCustomer(customerEntity: CustomerEntity) {
+        customerDao.insertCustomer(customerEntity)
+    }
+
+    override suspend fun updateCustomer(customerEntity: CustomerEntity) {
+        customerDao.updateCustomer(customerEntity)
+    }
+
+    override suspend fun deleteCustomer(customerEntity: CustomerEntity) {
+        customerDao.deleteCustomer(customerEntity)
+    }
+
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/data/di/DataSourceModule.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/data/di/DataSourceModule.kt
@@ -1,0 +1,17 @@
+package com.dkproject.regularcustomermanagement.data.di
+
+import com.dkproject.regularcustomermanagement.data.datasource.CustomerDataSource
+import com.dkproject.regularcustomermanagement.data.datasource.CustomerDataSourceImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DataSourceModule {
+    @Binds
+    abstract fun bindCustomerDataSource(
+        customerDataSourceImpl: CustomerDataSourceImpl
+    ): CustomerDataSource
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/data/di/RepositoryModule.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/data/di/RepositoryModule.kt
@@ -1,0 +1,17 @@
+package com.dkproject.regularcustomermanagement.data.di
+
+import com.dkproject.regularcustomermanagement.data.repository.CustomerRepositoryImpl
+import com.dkproject.regularcustomermanagement.domain.repository.CustomerRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+    @Binds
+    abstract fun bindCustomerRepository(
+        customerRepositoryImpl: CustomerRepositoryImpl
+    ): CustomerRepository
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/data/di/UseCaseModule.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/data/di/UseCaseModule.kt
@@ -1,0 +1,21 @@
+package com.dkproject.regularcustomermanagement.data.di
+
+import com.dkproject.regularcustomermanagement.domain.repository.CustomerRepository
+import com.dkproject.regularcustomermanagement.domain.usecase.AddCustomerUseCase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object UseCaseModule {
+    @Provides
+    @Singleton
+    fun provideAddCustomerUseCase(
+        customerRepository: CustomerRepository
+    ): AddCustomerUseCase {
+        return AddCustomerUseCase(customerRepository)
+    }
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/data/model/CustomerEntity.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/data/model/CustomerEntity.kt
@@ -37,3 +37,19 @@ data class CustomerEntity(
         )
     }
 }
+
+fun Customer.toEntity(): CustomerEntity {
+    return CustomerEntity(
+        id = id,
+        name = name,
+        carNumber = carNumber,
+        affiliation = affiliation,
+        visitedList = visitedList,
+        phoneNumber = phoneNumber,
+        memoList = memoList,
+        isStar = isStar,
+        nickName = nickName,
+        createdAt = createdAt,
+        tags = tags
+    )
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/data/repository/CustomerRepositoryImpl.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/data/repository/CustomerRepositoryImpl.kt
@@ -1,0 +1,32 @@
+package com.dkproject.regularcustomermanagement.data.repository
+
+import com.dkproject.regularcustomermanagement.data.datasource.CustomerDataSource
+import com.dkproject.regularcustomermanagement.data.model.toEntity
+import com.dkproject.regularcustomermanagement.domain.model.Customer
+import com.dkproject.regularcustomermanagement.domain.repository.CustomerRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class CustomerRepositoryImpl @Inject constructor(
+    private val customerDataSource: CustomerDataSource
+): CustomerRepository{
+    override fun getAllCustomers(): Flow<List<Customer>> {
+        return customerDataSource.getAllCustomers().map { list ->
+            list.map { it.toDomain() }
+        }
+    }
+
+    override suspend fun addCustomer(customer: Customer): Result<Unit> = runCatching {
+        customerDataSource.addCustomer(customer.toEntity())
+    }
+
+    override suspend fun updateCustomer(customer: Customer): Result<Unit> = runCatching {
+        customerDataSource.updateCustomer(customer.toEntity())
+    }
+    override suspend fun deleteCustomer(customer: Customer): Result<Unit> = runCatching {
+        customerDataSource.deleteCustomer(customer.toEntity())
+    }
+
+
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/domain/model/Customer.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/domain/model/Customer.kt
@@ -1,9 +1,11 @@
 package com.dkproject.regularcustomermanagement.domain.model
 
 import java.util.Date
+import java.util.UUID
+import kotlin.uuid.Uuid
 
 data class Customer(
-    val id: String = "", //고객 아이디
+    val id: String = UUID.randomUUID().toString(), //고객 아이디
     val name: String = "", // 고객 이름
     val carNumber: String? = null, // 고객 차량 번호
     val affiliation: String? = null, // 고객 소속

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/domain/model/Customer.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/domain/model/Customer.kt
@@ -3,15 +3,15 @@ package com.dkproject.regularcustomermanagement.domain.model
 import java.util.Date
 
 data class Customer(
-    val id: String, //고객 아이디
-    val name: String, // 고객 이름
-    val carNumber: String?, // 고객 차량 번호
-    val affiliation: String?, // 고객 소속
-    val visitedList: List<Date>, // 고객 방문 리스트
-    val phoneNumber: String?, // 고객 휴대폰 번호
-    val memoList: List<String>, // 고객 메모 리스트
-    val isStar: Boolean, // 고객 즐겨찾기 여부
-    val nickName: String?, // 고객 닉네임
-    val createdAt: Date, // 고객 생성 날짜
-    val tags: List<String> // 고객 태그 리스트
+    val id: String = "", //고객 아이디
+    val name: String = "", // 고객 이름
+    val carNumber: String? = null, // 고객 차량 번호
+    val affiliation: String? = null, // 고객 소속
+    val visitedList: List<Date> = emptyList(), // 고객 방문 리스트
+    val phoneNumber: String? = null, // 고객 휴대폰 번호
+    val memoList: List<String> = emptyList(), // 고객 메모 리스트
+    val isStar: Boolean = false, // 고객 즐겨찾기 여부
+    val nickName: String? = null, // 고객 닉네임
+    val createdAt: Date = Date(), // 고객 생성 날짜
+    val tags: List<String> = emptyList() // 고객 태그 리스트
 )

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/domain/repository/CustomerRepository.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/domain/repository/CustomerRepository.kt
@@ -1,0 +1,11 @@
+package com.dkproject.regularcustomermanagement.domain.repository
+
+import com.dkproject.regularcustomermanagement.domain.model.Customer
+import kotlinx.coroutines.flow.Flow
+
+interface CustomerRepository {
+    fun getAllCustomers(): Flow<List<Customer>>
+    suspend fun addCustomer(customer: Customer): Result<Unit>
+    suspend fun updateCustomer(customer: Customer): Result<Unit>
+    suspend fun deleteCustomer(customer: Customer): Result<Unit>
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/domain/usecase/AddCustomerUseCase.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/domain/usecase/AddCustomerUseCase.kt
@@ -1,0 +1,10 @@
+package com.dkproject.regularcustomermanagement.domain.usecase
+
+import com.dkproject.regularcustomermanagement.domain.model.Customer
+import com.dkproject.regularcustomermanagement.domain.repository.CustomerRepository
+
+class AddCustomerUseCase(
+    private val customerRepository: CustomerRepository
+) {
+    suspend operator fun invoke(customer: Customer): Result<Unit> = customerRepository.addCustomer(customer)
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/AdaptiveScaffold.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/AdaptiveScaffold.kt
@@ -6,16 +6,21 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PermanentDrawerSheet
 import androidx.compose.material3.PermanentNavigationDrawer
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import com.dkproject.regularcustomermanagement.R
 
 @Composable
 fun AdaptiveScaffold(
@@ -23,25 +28,51 @@ fun AdaptiveScaffold(
     windowSize: WindowWidthSizeClass,
     content: @Composable (PaddingValues) -> Unit
 ) {
+    val currentBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = currentBackStackEntry?.destination?.route
+
     when (windowSize) {
         WindowWidthSizeClass.Compact -> {
             Scaffold(
-                bottomBar = { BottomNavigationBar(navController = navController) }
+                topBar = { CompactTopAppBar(currentRoute = currentRoute)},
+                bottomBar = {
+                    BottomNavigationBar(
+                        navController = navController,
+                        currentRoute = currentRoute
+                    )
+                },
+                floatingActionButton = {
+                    FloatingButton(
+                        navController = navController,
+                        currentRoute = currentRoute,
+                        shape = CircleShape
+                    )
+                }
             ) { innerPadding ->
                 Box(modifier = Modifier.padding(innerPadding))
                 content(innerPadding)
             }
         }
+
         WindowWidthSizeClass.Medium -> {
             Scaffold { innerPadding ->
-                Row(modifier = Modifier.padding(innerPadding).fillMaxSize()) {
+                Row(
+                    modifier = Modifier
+                        .padding(innerPadding)
+                        .fillMaxSize()
+                ) {
                     NavigationRailContent(navController = navController)
-                    Box(modifier = Modifier.fillMaxSize().padding(start = 16.dp)) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(start = 16.dp)
+                    ) {
                         content(PaddingValues())
                     }
                 }
             }
         }
+
         WindowWidthSizeClass.Expanded -> {
             PermanentNavigationDrawer(
                 drawerContent = {

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/BottomNavigationBar.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/BottomNavigationBar.kt
@@ -1,6 +1,7 @@
 package com.dkproject.regularcustomermanagement.presentation.Component
 
 import android.util.Log
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
@@ -12,37 +13,52 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.toRoute
 import com.dkproject.regularcustomermanagement.presentation.navigation.TabScreen
+import com.dkproject.regularcustomermanagement.presentation.navigation.TabScreenList.tabNavItem
 
 @Composable
 fun BottomNavigationBar(
     navController: NavHostController,
+    currentRoute : String? = null
 ) {
-    val navItem = listOf(
-        TabScreen.Home,
-        TabScreen.Customer,
-        TabScreen.Handover
-    )
-    val currentBackStackEntry by navController.currentBackStackEntryAsState()
-    NavigationBar {
-        navItem.forEach { item ->
-            NavigationBarItem(
-                selected = item.route == currentBackStackEntry?.destination?.route,
-                onClick = {
-                    navController.navigate(item.route) {
-                        popUpTo(navController.graph.id) {
-                            saveState = true
+    val navItem = tabNavItem
+    AnimatedVisibility(navItem.any { it.route == currentRoute }) {
+        NavigationBar(tonalElevation = 0.dp) {
+            navItem.forEach { item ->
+                NavigationBarItem(
+                    selected = item.route == currentRoute,
+                    onClick = {
+                        navController.navigate(item.route) {
+                            popUpTo(navController.graph.id) {
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState = true
                         }
-                        launchSingleTop = true
-                        restoreState = true
-                    }
-                },
-                icon = { Icon(imageVector = item.icon, contentDescription = stringResource(item.description)) },
-                label = { Text(text = stringResource(item.title), fontWeight = FontWeight.Bold) },
-            )
+                    },
+                    icon = {
+                        Icon(
+                            imageVector = item.icon,
+                            contentDescription = stringResource(item.description)
+                        )
+                    },
+                    label = {
+                        Text(
+                            text = stringResource(item.title),
+                            fontWeight = FontWeight.Bold
+                        )
+                    },
+                    colors = NavigationBarItemDefaults.colors(
+                        indicatorColor = Color.Transparent,
+                        selectedIconColor = MaterialTheme.colorScheme.primary,
+                        selectedTextColor = MaterialTheme.colorScheme.primary
+                    )
+                )
+            }
         }
     }
 }

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/Button/BasicButton.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/Button/BasicButton.kt
@@ -1,0 +1,28 @@
+package com.dkproject.regularcustomermanagement.presentation.Component.Button
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.dimensionResource
+import com.dkproject.regularcustomermanagement.R
+
+@Composable
+fun BasicButton(
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    shape: Shape = RoundedCornerShape(dimensionResource(R.dimen.padding_small)),
+    enabled: Boolean = true,
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        shape = shape,
+        modifier = modifier
+    ) {
+        Text(text = title)
+    }
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/Button/BasicButton.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/Button/BasicButton.kt
@@ -1,9 +1,12 @@
 package com.dkproject.regularcustomermanagement.presentation.Component.Button
 
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.dimensionResource
@@ -14,6 +17,7 @@ fun BasicButton(
     title: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    loading: Boolean = false,
     shape: Shape = RoundedCornerShape(dimensionResource(R.dimen.padding_small)),
     enabled: Boolean = true,
 ) {
@@ -23,6 +27,9 @@ fun BasicButton(
         shape = shape,
         modifier = modifier
     ) {
-        Text(text = title)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(text = title)
+            if(loading) CircularProgressIndicator()
+        }
     }
 }

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/Button/TagChip.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/Button/TagChip.kt
@@ -1,0 +1,70 @@
+package com.dkproject.regularcustomermanagement.presentation.Component.Button
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.InputChipDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.dkproject.regularcustomermanagement.R
+import com.dkproject.regularcustomermanagement.presentation.theme.RegularCustomerManagementTheme
+
+@Composable
+fun TagChip(
+    tag: String,
+    modifier: Modifier = Modifier,
+    isDelete: Boolean = false,
+    shape: Shape = RoundedCornerShape(dimensionResource(R.dimen.padding_medium)),
+    onDelete: () -> Unit = {},
+) {
+    Surface(
+        modifier = modifier,
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        shape = shape,
+    ) {
+        Row(
+            modifier = Modifier.padding(
+                horizontal = dimensionResource(R.dimen.padding_small),
+                vertical = dimensionResource(R.dimen.padding_six)
+            ),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = tag,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Bold
+            )
+            if (isDelete)
+                IconButton(onDelete, modifier = Modifier.size(InputChipDefaults.AvatarSize)) {
+                    Icon(Icons.Default.Close, null)
+                }
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun TagChipPreview() {
+    RegularCustomerManagementTheme {
+        Column(modifier = Modifier.fillMaxSize()) {
+            TagChip("Tag", isDelete = true)
+        }
+    }
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/CompactTopAppBar.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/CompactTopAppBar.kt
@@ -1,0 +1,35 @@
+package com.dkproject.regularcustomermanagement.presentation.Component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import com.dkproject.regularcustomermanagement.R
+import com.dkproject.regularcustomermanagement.presentation.navigation.TabScreen
+import com.dkproject.regularcustomermanagement.presentation.navigation.TabScreenList.tabNavItem
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CompactTopAppBar(
+    currentRoute: String?
+) {
+    val title = when (currentRoute) {
+        TabScreen.Home.route -> stringResource(R.string.home)
+        TabScreen.Customer.route -> stringResource(R.string.customer)
+        TabScreen.Handover.route -> stringResource(R.string.handover)
+        else -> ""
+    }
+    AnimatedVisibility(tabNavItem.any { it.route == currentRoute }) {
+        Column {
+            TopAppBar(title = { Text(title, fontWeight = FontWeight.Bold) })
+            AnimatedVisibility(currentRoute == TabScreen.Customer.route) {
+                Text("검색바")
+            }
+        }
+    }
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/FloatingButton.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/FloatingButton.kt
@@ -1,0 +1,42 @@
+package com.dkproject.regularcustomermanagement.presentation.Component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.FloatingActionButtonElevation
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavHostController
+import com.dkproject.regularcustomermanagement.R
+import com.dkproject.regularcustomermanagement.presentation.navigation.DetailScreen
+import com.dkproject.regularcustomermanagement.presentation.navigation.TabScreen
+import com.dkproject.regularcustomermanagement.presentation.navigation.TabScreenList
+import com.dkproject.regularcustomermanagement.presentation.navigation.TabScreenList.tabFloatingItem
+
+@Composable
+fun FloatingButton(
+    navController: NavHostController,
+    shape: Shape = FloatingActionButtonDefaults.shape,
+    elevation: FloatingActionButtonElevation = FloatingActionButtonDefaults.elevation(),
+    currentRoute: String? = null,
+) {
+    AnimatedVisibility(tabFloatingItem.any { it.route == currentRoute }) {
+        FloatingActionButton(
+            onClick = {
+                when (currentRoute) {
+                    TabScreen.Home.route -> {}
+                    TabScreen.Customer.route -> { navController.navigate(DetailScreen.CreateCustomer)}
+                }
+            },
+            shape = shape,
+            elevation = elevation
+        ) {
+            Icon(Icons.Filled.Add, "description")
+        }
+    }
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/TexetField/DefaultTextField.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/TexetField/DefaultTextField.kt
@@ -1,0 +1,93 @@
+package com.dkproject.regularcustomermanagement.presentation.Component.TexetField
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.dkproject.regularcustomermanagement.R
+import com.dkproject.regularcustomermanagement.presentation.theme.RegularCustomerManagementTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DefaultTextField(
+    modifier: Modifier = Modifier,
+    value: String,
+    placeholder: String = "",
+    onValueChange: (String) -> Unit = {},
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    maxLines: Int = Int.MAX_VALUE,
+    enabled: Boolean = true,
+    isError: Boolean = false,
+    textStyle: TextStyle = TextStyle.Default,
+    interactionSource: InteractionSource,
+    shape: Shape = RoundedCornerShape(dimensionResource(R.dimen.padding_small))
+) {
+    BasicTextField(
+        modifier = modifier,
+        value = value,
+        onValueChange = onValueChange,
+        keyboardOptions = keyboardOptions,
+        maxLines = maxLines,
+        singleLine = maxLines == 1,
+        textStyle = textStyle
+    ) { innerTextField ->
+        OutlinedTextFieldDefaults.DecorationBox(
+            value = value,
+            innerTextField = innerTextField,
+            enabled = enabled,
+            isError = isError,
+            singleLine = maxLines == 1,
+            placeholder = { Text(text = placeholder) },
+            visualTransformation = VisualTransformation.None,
+            interactionSource = interactionSource
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun DefaultTextFieldPreview() {
+    RegularCustomerManagementTheme {
+        Column(modifier = Modifier.fillMaxSize()) {
+            var text by remember { mutableStateOf("") }
+            DefaultTextField(
+                value = text,
+                onValueChange = { text = it },
+                modifier = Modifier
+                    .height(240.dp)
+                    .padding(24.dp)
+                    .fillMaxWidth(),
+                interactionSource = remember {  MutableInteractionSource() }
+            )
+        }
+    }
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/TexetField/InputTextField.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/TexetField/InputTextField.kt
@@ -1,0 +1,49 @@
+package com.dkproject.regularcustomermanagement.presentation.Component.TexetField
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.dkproject.regularcustomermanagement.R
+
+@Composable
+fun InputTextField(
+    modifier: Modifier = Modifier,
+    value: String,
+    onValueChange: (String) -> Unit,
+    enabled: Boolean = true,
+    maxLines: Int = 1,
+    placeholder: String,
+    isError: Boolean = false,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    shape: RoundedCornerShape = RoundedCornerShape(dimensionResource(R.dimen.padding_small))
+) {
+    OutlinedTextField(
+        modifier = modifier,
+        value = value,
+        onValueChange = onValueChange,
+        enabled = enabled,
+        maxLines = maxLines,
+        singleLine = maxLines == 1,
+        placeholder = { Text(text = placeholder) },
+        shape = shape,
+        isError = isError,
+        keyboardOptions = keyboardOptions,
+    )
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun InputTextFieldPreview() {
+    Column(modifier = Modifier.fillMaxSize()) {
+        InputTextField(value = "", onValueChange = {}, placeholder = "테스트", modifier = Modifier.padding(24.dp))
+    }
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/TexetField/InputTextField.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/TexetField/InputTextField.kt
@@ -2,6 +2,7 @@ package com.dkproject.regularcustomermanagement.presentation.Component.TexetFiel
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
@@ -44,6 +45,6 @@ fun InputTextField(
 @Preview(showBackground = true)
 private fun InputTextFieldPreview() {
     Column(modifier = Modifier.fillMaxSize()) {
-        InputTextField(value = "", onValueChange = {}, placeholder = "테스트", modifier = Modifier.padding(24.dp))
+        InputTextField(value = "", onValueChange = {}, placeholder = "테스트", modifier = Modifier.padding(24.dp).height(300.dp))
     }
 }

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/TexetField/InputTextField.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/TexetField/InputTextField.kt
@@ -6,11 +6,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.dkproject.regularcustomermanagement.R
@@ -22,6 +25,10 @@ fun InputTextField(
     onValueChange: (String) -> Unit,
     enabled: Boolean = true,
     maxLines: Int = 1,
+    textStyle: TextStyle = TextStyle.Default.copy(
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.scrim
+    ),
     placeholder: String,
     isError: Boolean = false,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
@@ -32,6 +39,7 @@ fun InputTextField(
         value = value,
         onValueChange = onValueChange,
         enabled = enabled,
+        textStyle = textStyle,
         maxLines = maxLines,
         singleLine = maxLines == 1,
         placeholder = { Text(text = placeholder) },

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/Text/AnimatedStepText.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/Text/AnimatedStepText.kt
@@ -1,0 +1,24 @@
+package com.dkproject.regularcustomermanagement.presentation.Component.Text
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+
+@Composable
+fun AnimatedStepText(
+    text: String,
+    isSelected: Boolean,
+    modifier: Modifier = Modifier
+) {
+    AnimatedContent(targetState = isSelected, label = "") { selected ->
+        val color = if (selected) MaterialTheme.colorScheme.primary else Color.Gray
+        Text(text, color = color)
+    }
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/Text/MemoTextBox.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/Component/Text/MemoTextBox.kt
@@ -1,0 +1,63 @@
+package com.dkproject.regularcustomermanagement.presentation.Component.Text
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.dkproject.regularcustomermanagement.R
+import com.dkproject.regularcustomermanagement.presentation.theme.RegularCustomerManagementTheme
+
+@Composable
+fun MemoTextBox(
+    modifier: Modifier = Modifier,
+    shape: Shape = RoundedCornerShape(dimensionResource(R.dimen.padding_small)),
+    value: String,
+    isDelete: Boolean = false,
+    onDeleteClick: () -> Unit = {},
+) {
+    Surface(
+        modifier = modifier,
+        shape = shape,
+        color = MaterialTheme.colorScheme.background,
+    ) {
+        Row(modifier = Modifier.fillMaxWidth(),verticalAlignment = Alignment.Top) {
+            Text(text = value, modifier = Modifier
+                .fillMaxWidth(0.85f)
+                .padding(dimensionResource(R.dimen.padding_small)))
+            if(isDelete) {
+                IconButton(onDeleteClick, modifier = Modifier.padding(horizontal = dimensionResource(R.dimen.padding_small))) {
+                    Icon(Icons.Default.Close, null, tint = Color.Black)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun MemoTextBoxPreview() {
+    RegularCustomerManagementTheme {
+        Column(modifier = Modifier.fillMaxSize()) {
+            MemoTextBox(
+                value = "이사람 개쩜",
+                isDelete = true
+            )
+        }
+    }
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/model/BaseUiEvent.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/model/BaseUiEvent.kt
@@ -1,0 +1,6 @@
+package com.dkproject.regularcustomermanagement.presentation.model
+
+sealed class BaseUiEvent {
+    data class ShowToast(val message: String) : BaseUiEvent()
+    data object PopBackStack : BaseUiEvent()
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/model/BaseUiEvent.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/model/BaseUiEvent.kt
@@ -1,6 +1,8 @@
 package com.dkproject.regularcustomermanagement.presentation.model
 
+import androidx.annotation.StringRes
+
 sealed class BaseUiEvent {
-    data class ShowToast(val message: String) : BaseUiEvent()
+    data class ShowToast(@StringRes val message: Int) : BaseUiEvent()
     data object PopBackStack : BaseUiEvent()
 }

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/model/BasicInfo.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/model/BasicInfo.kt
@@ -1,0 +1,8 @@
+package com.dkproject.regularcustomermanagement.presentation.model
+
+data class BasicInfo (
+    val name: String = "",
+    val phoneNumber: String? = null,
+    val nickName: String? = null,
+    val carNumber: String? = null
+)

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/model/CreateCustomerStep.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/model/CreateCustomerStep.kt
@@ -1,0 +1,11 @@
+package com.dkproject.regularcustomermanagement.presentation.model
+
+import androidx.annotation.StringRes
+import com.dkproject.regularcustomermanagement.R
+
+
+enum class CreateCustomerStep(@StringRes val label: Int, val progress: Float) {
+    BASIC(label = R.string.basicinfo, progress = 0.1f),
+    AFFILIATION(label = R.string.affiliationtag, progress = 0.5f),
+    MEMO(label = R.string.memo, progress = 1.0f)
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/navigation/AppNavigation.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/navigation/AppNavigation.kt
@@ -4,18 +4,24 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.dkproject.regularcustomermanagement.presentation.ui.createCustomer.CreateCustomerScreen
+import com.dkproject.regularcustomermanagement.presentation.ui.createCustomer.CreateCustomerViewModel
+import com.dkproject.regularcustomermanagement.presentation.ui.customer.CustomerScreen
 
 @Composable
 fun AppNavigation(
     navController: NavHostController = rememberNavController(),
     modifier: Modifier = Modifier,
 ) {
-    NavHost(navController = navController, startDestination = TabScreen.Home.route) {
+    NavHost(navController = navController, startDestination = DetailScreen.CreateCustomer) {
         composable(TabScreen.Home.route) {
             Column(modifier = modifier) {
                 Text("this is home")
@@ -23,7 +29,20 @@ fun AppNavigation(
         }
 
         composable(TabScreen.Customer.route) {
-            Text("this is customer")
+            CustomerScreen(modifier = modifier)
+        }
+
+        composable<DetailScreen.CreateCustomer> {
+            val viewModel: CreateCustomerViewModel = hiltViewModel()
+            val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+            CreateCustomerScreen(
+                uiState = uiState, onMoveStep = viewModel::updateCurrentStep,
+                popBackStack = { navController.popBackStack() },
+                updateBasicInfo = viewModel::updateBasicInfo,
+                updateAffiliationAndTags = viewModel::updateAffiliationAndTags,
+                updateStarAndMemo = viewModel::updateStarAndMemo,
+                onCompleted = viewModel::addCustomer
+            )
         }
 
         composable(TabScreen.Handover.route) {

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/navigation/AppNavigation.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/navigation/AppNavigation.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
@@ -25,7 +26,7 @@ fun AppNavigation(
     navController: NavHostController = rememberNavController(),
     modifier: Modifier = Modifier,
 ) {
-    NavHost(navController = navController, startDestination = DetailScreen.CreateCustomer) {
+    NavHost(navController = navController, startDestination = TabScreen.Home.route) {
         composable(TabScreen.Home.route) {
             Column(modifier = modifier) {
                 Text("this is home")
@@ -45,7 +46,8 @@ fun AppNavigation(
                     when (event) {
                         BaseUiEvent.PopBackStack -> { navController.popBackStack() }
                         is BaseUiEvent.ShowToast -> {
-                            Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
+                            val message = context.getString(event.message)
+                            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
                         }
                     }
                 }

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/navigation/AppNavigation.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/navigation/AppNavigation.kt
@@ -1,17 +1,21 @@
 package com.dkproject.regularcustomermanagement.presentation.navigation
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.dkproject.regularcustomermanagement.presentation.model.BaseUiEvent
 import com.dkproject.regularcustomermanagement.presentation.ui.createCustomer.CreateCustomerScreen
 import com.dkproject.regularcustomermanagement.presentation.ui.createCustomer.CreateCustomerViewModel
 import com.dkproject.regularcustomermanagement.presentation.ui.customer.CustomerScreen
@@ -33,8 +37,19 @@ fun AppNavigation(
         }
 
         composable<DetailScreen.CreateCustomer> {
+            val context = LocalContext.current
             val viewModel: CreateCustomerViewModel = hiltViewModel()
             val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+            LaunchedEffect(Unit) {
+                viewModel.uiEvent.collect { event ->
+                    when (event) {
+                        BaseUiEvent.PopBackStack -> { navController.popBackStack() }
+                        is BaseUiEvent.ShowToast -> {
+                            Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                }
+            }
             CreateCustomerScreen(
                 uiState = uiState, onMoveStep = viewModel::updateCurrentStep,
                 popBackStack = { navController.popBackStack() },

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/navigation/NavigationData.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/navigation/NavigationData.kt
@@ -1,6 +1,5 @@
 package com.dkproject.regularcustomermanagement.presentation.navigation
 
-import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
@@ -16,4 +15,22 @@ sealed class TabScreen(
     data object Home: TabScreen("home", Icons.Filled.Home, R.string.home, R.string.home)
     data object Customer: TabScreen("customer", Icons.Filled.PersonPin, R.string.customer, R.string.customer)
     data object Handover: TabScreen("handover", Icons.Filled.SwapHorizontalCircle, R.string.handover, R.string.handover)
+}
+
+sealed class DetailScreen {
+    @Serializable
+    data object CreateCustomer: DetailScreen()
+}
+
+object TabScreenList {
+    val tabNavItem = listOf(
+        TabScreen.Home,
+        TabScreen.Customer,
+        TabScreen.Handover
+    )
+
+    val tabFloatingItem = listOf(
+        TabScreen.Home,
+        TabScreen.Customer,
+    )
 }

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/theme/Color.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/theme/Color.kt
@@ -2,11 +2,13 @@ package com.dkproject.regularcustomermanagement.presentation.theme
 
 import androidx.compose.ui.graphics.Color
 
-val primaryLight = Color(0xFF5D5F5F)
-val onPrimaryLight = Color(0xFFFFFFFF)
+val primaryLight = Color(0xFF0A5AE3)         // 선택된 색상
+val onPrimaryLight = Color(0xFFFFFFFF)       // 버튼 내부 텍스트/아이콘
+val surfaceLight = Color(0xFFFFFFFF)         // 바텀 네비게이션 배경
+val onSurfaceLight = Color(0xFF5D5F5F)       // 비선택 상태의 텍스트/아이콘
+val secondaryLight = Color(0xFF5D5F5F)       // 보조 텍스트 or 아이콘
 val primaryContainerLight = Color(0xFFFFFFFF)
 val onPrimaryContainerLight = Color(0xFF747676)
-val secondaryLight = Color(0xFF5E5E5E)
 val onSecondaryLight = Color(0xFFFFFFFF)
 val secondaryContainerLight = Color(0xFFE4E2E2)
 val onSecondaryContainerLight = Color(0xFF646464)
@@ -18,10 +20,8 @@ val errorLight = Color(0xFFBA1A1A)
 val onErrorLight = Color(0xFFFFFFFF)
 val errorContainerLight = Color(0xFFFFDAD6)
 val onErrorContainerLight = Color(0xFF93000A)
-val backgroundLight = Color(0xFFFCF8F8)
+val backgroundLight = Color(0XFFF8F9FA)
 val onBackgroundLight = Color(0xFF1C1B1B)
-val surfaceLight = Color(0xFFFCF8F8)
-val onSurfaceLight = Color(0xFF1C1B1B)
 val surfaceVariantLight = Color(0xFFE0E3E3)
 val onSurfaceVariantLight = Color(0xFF444748)
 val outlineLight = Color(0xFF747878)
@@ -38,8 +38,10 @@ val surfaceContainerLight = Color(0xFFF1EDEC)
 val surfaceContainerHighLight = Color(0xFFEBE7E7)
 val surfaceContainerHighestLight = Color(0xFFE5E2E1)
 
-val primaryDark = Color(0xFFFFFFFF)
-val onPrimaryDark = Color(0xFF2F3131)
+val primaryDark = Color(0xFF82B4FF)          // 다크에서 강조 (light primary의 밝은 버전)
+val onPrimaryDark = Color(0xFF001B42)        // 텍스트 대비
+val surfaceDark = Color(0xFF1C1C1E)          // 바텀 네비게이션 배경
+val onSurfaceDark = Color(0xFFC7C7CC)
 val primaryContainerDark = Color(0xFFE2E2E2)
 val onPrimaryContainerDark = Color(0xFF636565)
 val secondaryDark = Color(0xFFC8C6C6)
@@ -56,8 +58,6 @@ val errorContainerDark = Color(0xFF93000A)
 val onErrorContainerDark = Color(0xFFFFDAD6)
 val backgroundDark = Color(0xFF141313)
 val onBackgroundDark = Color(0xFFE5E2E1)
-val surfaceDark = Color(0xFF141313)
-val onSurfaceDark = Color(0xFFE5E2E1)
 val surfaceVariantDark = Color(0xFF444748)
 val onSurfaceVariantDark = Color(0xFFC4C7C8)
 val outlineDark = Color(0xFF8E9192)

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/theme/Theme.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/theme/Theme.kt
@@ -95,11 +95,6 @@ fun RegularCustomerManagementTheme(
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
-
         darkTheme -> darkScheme
         else -> lightScheme
     }

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/AffiliationInfo/AffiliationInfoScreen.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/AffiliationInfo/AffiliationInfoScreen.kt
@@ -1,0 +1,131 @@
+package com.dkproject.regularcustomermanagement.presentation.ui.createCustomer.AffiliationInfo
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.dkproject.regularcustomermanagement.R
+import com.dkproject.regularcustomermanagement.presentation.Component.Button.BasicButton
+import com.dkproject.regularcustomermanagement.presentation.Component.Button.TagChip
+import com.dkproject.regularcustomermanagement.presentation.Component.TexetField.InputTextField
+import com.dkproject.regularcustomermanagement.presentation.theme.RegularCustomerManagementTheme
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun AffiliationInfoScreen(
+    viewModel: AffiliationViewModel = hiltViewModel(),
+    modifier: Modifier = Modifier,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var tagString by rememberSaveable { mutableStateOf("") }
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(dimensionResource(R.dimen.padding_small)))
+            .background(MaterialTheme.colorScheme.onSecondary)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(dimensionResource(R.dimen.padding_medium))
+                .verticalScroll(rememberScrollState())
+        ) {
+            // Name Section
+            Text(
+                modifier = modifier,
+                text = stringResource(R.string.tag),
+                fontWeight = FontWeight.Bold
+            )
+            AnimatedVisibility(uiState.tags.isNotEmpty()) {
+                FlowRow(
+                    modifier = Modifier.padding(vertical = dimensionResource(R.dimen.padding_small)),
+                    horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.padding_small)),
+                    verticalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.padding_four))
+                ) {
+                    uiState.tags.forEach { tag ->
+                        TagChip(tag = tag, isDelete = true) {
+                            viewModel.removeTag(tag)
+                        }
+                    }
+                }
+            }
+            Row(
+                modifier = Modifier.padding(top = dimensionResource(R.dimen.padding_small)),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                InputTextField(
+                    value = tagString,
+                    onValueChange = { tagString = it },
+                    placeholder = stringResource(R.string.tag),
+                    modifier = Modifier
+                        .weight(3f)
+                )
+                Spacer(modifier = Modifier.width(dimensionResource(R.dimen.padding_medium)))
+                // add Tag
+                BasicButton(
+                    title = stringResource(R.string.add),
+                    onClick = {
+                        viewModel.addTag(tagString)
+                        tagString = ""
+                    },
+                    modifier = Modifier.weight(1f),
+                    enabled = tagString.isNotEmpty() && !uiState.tags.contains(tagString) && uiState.tags.count() < 8
+                )
+            }
+            AnimatedVisibility(uiState.tags.count() >= 8) {
+                Text(
+                    modifier = Modifier.padding(top = dimensionResource(R.dimen.padding_six)).fillMaxWidth(),
+                    text = stringResource(R.string.maxtag),
+                    style = MaterialTheme.typography.labelMedium,
+                    textAlign = TextAlign.End
+                )
+            }
+            // Next Button
+            BasicButton(
+                title = stringResource(R.string.next),
+                onClick = {
+
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = dimensionResource(R.dimen.padding_medium))
+            )
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun AffiliationInfoPreview() {
+    RegularCustomerManagementTheme {
+        AffiliationInfoScreen()
+    }
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/AffiliationInfo/AffiliationInfoScreen.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/AffiliationInfo/AffiliationInfoScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -28,6 +29,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -43,22 +45,33 @@ import com.dkproject.regularcustomermanagement.presentation.theme.RegularCustome
 fun AffiliationInfoScreen(
     viewModel: AffiliationViewModel = hiltViewModel(),
     modifier: Modifier = Modifier,
+    onNextStep: (String, List<String>) -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var tagString by rememberSaveable { mutableStateOf("") }
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(dimensionResource(R.dimen.padding_small)))
-            .background(MaterialTheme.colorScheme.onSecondary)
-    ) {
+    Column(modifier = modifier) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .clip(RoundedCornerShape(dimensionResource(R.dimen.padding_small)))
+                .background(MaterialTheme.colorScheme.onSecondary)
                 .padding(dimensionResource(R.dimen.padding_medium))
                 .verticalScroll(rememberScrollState())
         ) {
-            // Name Section
+            // Affiliations Section
+            Text(
+                modifier = modifier,
+                text = stringResource(R.string.affiliationtag),
+                fontWeight = FontWeight.Bold
+            )
+            InputTextField(
+                value = uiState.affiliationName,
+                onValueChange = viewModel::updateAffiliationName,
+                placeholder = stringResource(R.string.affiliationtag),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                modifier = Modifier.fillMaxWidth().padding(vertical = dimensionResource(R.dimen.padding_small))
+            )
+            // Tag Section
             Text(
                 modifier = modifier,
                 text = stringResource(R.string.tag),
@@ -108,17 +121,17 @@ fun AffiliationInfoScreen(
                     textAlign = TextAlign.End
                 )
             }
-            // Next Button
-            BasicButton(
-                title = stringResource(R.string.next),
-                onClick = {
-
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = dimensionResource(R.dimen.padding_medium))
-            )
         }
+        // Next Button
+        BasicButton(
+            title = stringResource(R.string.next),
+            onClick = {
+                onNextStep(uiState.affiliationName, uiState.tags)
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = dimensionResource(R.dimen.padding_medium))
+        )
     }
 }
 
@@ -126,6 +139,6 @@ fun AffiliationInfoScreen(
 @Preview(showBackground = true)
 private fun AffiliationInfoPreview() {
     RegularCustomerManagementTheme {
-        AffiliationInfoScreen()
+        AffiliationInfoScreen(onNextStep = {_, _ ->})
     }
 }

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/AffiliationInfo/AffiliationViewModel.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/AffiliationInfo/AffiliationViewModel.kt
@@ -1,0 +1,32 @@
+package com.dkproject.regularcustomermanagement.presentation.ui.createCustomer.AffiliationInfo
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class AffiliationViewModel @Inject constructor(
+
+): ViewModel() {
+    private val _uiState = MutableStateFlow(AffiliationUiState())
+    val uiState = _uiState.asStateFlow()
+
+    fun updateAffiliationName(name: String) {
+        _uiState.value = _uiState.value.copy(affiliationName = name)
+    }
+
+    fun addTag(tag: String) {
+        _uiState.value = _uiState.value.copy(tags = _uiState.value.tags + tag)
+    }
+
+    fun removeTag(tag: String) {
+        _uiState.value = _uiState.value.copy(tags = _uiState.value.tags - tag)
+    }
+}
+
+data class AffiliationUiState(
+    val affiliationName: String = "",
+    val tags: List<String> = emptyList()
+)

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/BasicInfo/BasicInfoScreen.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/BasicInfo/BasicInfoScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -40,16 +41,13 @@ fun BasicInfoScreen(
     onNextStep: (BasicInfo) -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(dimensionResource(R.dimen.padding_small)))
-            .background(MaterialTheme.colorScheme.onSecondary)
-            .verticalScroll(rememberScrollState())
-    ) {
+    Column(modifier = modifier) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .clip(RoundedCornerShape(dimensionResource(R.dimen.padding_small)))
+                .background(MaterialTheme.colorScheme.onSecondary)
+                .verticalScroll(rememberScrollState())
                 .padding(dimensionResource(R.dimen.padding_medium))
         ) {
             // Name Section
@@ -64,7 +62,9 @@ fun BasicInfoScreen(
             )
             AnimatedVisibility(uiState.name.length > MAX_CUSTOMER_NAME_LENGTH) {
                 Text(
-                    modifier = Modifier.fillMaxWidth().padding(vertical = 3.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 3.dp),
                     text = stringResource(R.string.maxnamelength, MAX_CUSTOMER_NAME_LENGTH),
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.error,
@@ -88,7 +88,10 @@ fun BasicInfoScreen(
                 placeholder = stringResource(R.string.phoneplaceholder),
                 onValueChange = viewModel::updatePhoneNumber,
                 maxLine = 1,
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next, keyboardType = KeyboardType.Number),
+                keyboardOptions = KeyboardOptions(
+                    imeAction = ImeAction.Next,
+                    keyboardType = KeyboardType.Number
+                ),
                 modifier = Modifier.padding(top = dimensionResource(R.dimen.padding_medium))
             )
             // carNumber Section
@@ -101,22 +104,24 @@ fun BasicInfoScreen(
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                 modifier = Modifier.padding(top = dimensionResource(R.dimen.padding_medium))
             )
-            BasicButton(
-                title = stringResource(R.string.next),
-                onClick = {
-                    onNextStep(
-                        BasicInfo(
-                            name = uiState.name,
-                            phoneNumber = uiState.phoneNumber,
-                            nickName = uiState.nickName,
-                            carNumber = uiState.carNumber
-                        )
-                    )
-                },
-                enabled = (uiState.name.isNotEmpty() && uiState.name.length <= MAX_CUSTOMER_NAME_LENGTH),
-                modifier = Modifier.fillMaxWidth().padding(vertical = dimensionResource(R.dimen.padding_medium))
-            )
         }
+        BasicButton(
+            title = stringResource(R.string.next),
+            onClick = {
+                onNextStep(
+                    BasicInfo(
+                        name = uiState.name,
+                        phoneNumber = uiState.phoneNumber,
+                        nickName = uiState.nickName,
+                        carNumber = uiState.carNumber
+                    )
+                )
+            },
+            enabled = (uiState.name.isNotEmpty() && uiState.name.length <= MAX_CUSTOMER_NAME_LENGTH),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = dimensionResource(R.dimen.padding_medium))
+        )
     }
 }
 
@@ -128,10 +133,10 @@ private fun InputSection(
     onValueChange: (String) -> Unit,
     maxLine: Int = 1,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
-    isError : Boolean = false,
+    isError: Boolean = false,
     modifier: Modifier = Modifier
 ) {
-    Text(modifier = modifier,text = title, fontWeight = FontWeight.Bold)
+    Text(modifier = modifier, text = title, fontWeight = FontWeight.Bold)
     InputTextField(
         value = value ?: "",
         onValueChange = onValueChange,
@@ -150,6 +155,8 @@ private fun InputSection(
 @Preview(showBackground = true)
 private fun BasicInfoPreview() {
     RegularCustomerManagementTheme {
-        BasicInfoScreen(onNextStep = { })
+        Column(modifier = Modifier.fillMaxSize()) {
+            BasicInfoScreen(onNextStep = { })
+        }
     }
 }

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/BasicInfo/BasicInfoScreen.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/BasicInfo/BasicInfoScreen.kt
@@ -1,0 +1,155 @@
+package com.dkproject.regularcustomermanagement.presentation.ui.createCustomer.BasicInfo
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.dkproject.regularcustomermanagement.R
+import com.dkproject.regularcustomermanagement.presentation.Component.Button.BasicButton
+import com.dkproject.regularcustomermanagement.presentation.Component.TexetField.InputTextField
+import com.dkproject.regularcustomermanagement.presentation.model.BasicInfo
+import com.dkproject.regularcustomermanagement.presentation.theme.RegularCustomerManagementTheme
+import com.dkproject.regularcustomermanagement.presentation.utils.Constants.MAX_CUSTOMER_NAME_LENGTH
+
+@Composable
+fun BasicInfoScreen(
+    viewModel: BasicInfoViewModel = hiltViewModel(),
+    modifier: Modifier = Modifier,
+    onNextStep: (BasicInfo) -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(dimensionResource(R.dimen.padding_small)))
+            .background(MaterialTheme.colorScheme.onSecondary)
+            .verticalScroll(rememberScrollState())
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(dimensionResource(R.dimen.padding_medium))
+        ) {
+            // Name Section
+            InputSection(
+                value = uiState.name,
+                title = stringResource(R.string.name),
+                placeholder = stringResource(R.string.customername),
+                onValueChange = viewModel::updateUserName,
+                maxLine = 1,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                isError = uiState.name.length > MAX_CUSTOMER_NAME_LENGTH
+            )
+            AnimatedVisibility(uiState.name.length > MAX_CUSTOMER_NAME_LENGTH) {
+                Text(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 3.dp),
+                    text = stringResource(R.string.maxnamelength, MAX_CUSTOMER_NAME_LENGTH),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.error,
+                    textAlign = TextAlign.End
+                )
+            }
+            // Nickname Section
+            InputSection(
+                value = uiState.nickName,
+                title = stringResource(R.string.nickname),
+                placeholder = stringResource(R.string.nickname),
+                onValueChange = viewModel::updateNickname,
+                maxLine = 1,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next),
+                modifier = Modifier.padding(top = dimensionResource(R.dimen.padding_medium))
+            )
+            // PhoneNumber Section
+            InputSection(
+                value = uiState.phoneNumber,
+                title = stringResource(R.string.phonenumber),
+                placeholder = stringResource(R.string.phoneplaceholder),
+                onValueChange = viewModel::updatePhoneNumber,
+                maxLine = 1,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next, keyboardType = KeyboardType.Number),
+                modifier = Modifier.padding(top = dimensionResource(R.dimen.padding_medium))
+            )
+            // carNumber Section
+            InputSection(
+                value = uiState.carNumber,
+                title = stringResource(R.string.carnumber),
+                placeholder = stringResource(R.string.carnumber),
+                onValueChange = viewModel::updateCarNumber,
+                maxLine = 1,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                modifier = Modifier.padding(top = dimensionResource(R.dimen.padding_medium))
+            )
+            BasicButton(
+                title = stringResource(R.string.next),
+                onClick = {
+                    onNextStep(
+                        BasicInfo(
+                            name = uiState.name,
+                            phoneNumber = uiState.phoneNumber,
+                            nickName = uiState.nickName,
+                            carNumber = uiState.carNumber
+                        )
+                    )
+                },
+                enabled = (uiState.name.isNotEmpty() && uiState.name.length <= MAX_CUSTOMER_NAME_LENGTH),
+                modifier = Modifier.fillMaxWidth().padding(vertical = dimensionResource(R.dimen.padding_medium))
+            )
+        }
+    }
+}
+
+@Composable
+private fun InputSection(
+    value: String?,
+    title: String,
+    placeholder: String,
+    onValueChange: (String) -> Unit,
+    maxLine: Int = 1,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    isError : Boolean = false,
+    modifier: Modifier = Modifier
+) {
+    Text(modifier = modifier,text = title, fontWeight = FontWeight.Bold)
+    InputTextField(
+        value = value ?: "",
+        onValueChange = onValueChange,
+        placeholder = placeholder,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 6.dp),
+        keyboardOptions = keyboardOptions,
+        maxLines = maxLine,
+        isError = isError
+    )
+}
+
+
+@Composable
+@Preview(showBackground = true)
+private fun BasicInfoPreview() {
+    RegularCustomerManagementTheme {
+        BasicInfoScreen(onNextStep = { })
+    }
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/BasicInfo/BasicInfoViewModel.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/BasicInfo/BasicInfoViewModel.kt
@@ -1,0 +1,38 @@
+package com.dkproject.regularcustomermanagement.presentation.ui.createCustomer.BasicInfo
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class BasicInfoViewModel @Inject constructor(
+
+): ViewModel() {
+    private val _uiState = MutableStateFlow(BasicInfoUiState())
+    val uiState = _uiState.asStateFlow()
+
+    fun updateUserName(name: String) {
+        _uiState.value = _uiState.value.copy(name = name)
+    }
+
+    fun updateNickname(nickname: String) {
+        _uiState.value = _uiState.value.copy(nickName = nickname)
+    }
+
+    fun updatePhoneNumber(phoneNumber: String) {
+        _uiState.value = _uiState.value.copy(phoneNumber = phoneNumber)
+    }
+
+    fun updateCarNumber(carNumber: String) {
+        _uiState.value = _uiState.value.copy(carNumber = carNumber)
+    }
+}
+
+data class BasicInfoUiState(
+    val name: String = "",
+    val phoneNumber: String? = null,
+    val nickName: String? = null,
+    val carNumber: String? = null
+)

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/CreateCustomerScreen.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/CreateCustomerScreen.kt
@@ -1,0 +1,161 @@
+package com.dkproject.regularcustomermanagement.presentation.ui.createCustomer
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.animateIntAsState
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowLeft
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.dkproject.regularcustomermanagement.R
+import com.dkproject.regularcustomermanagement.presentation.Component.Text.AnimatedStepText
+import com.dkproject.regularcustomermanagement.presentation.model.BasicInfo
+import com.dkproject.regularcustomermanagement.presentation.model.CreateCustomerStep
+import com.dkproject.regularcustomermanagement.presentation.theme.RegularCustomerManagementTheme
+import com.dkproject.regularcustomermanagement.presentation.ui.createCustomer.AffiliationInfo.AffiliationInfoScreen
+import com.dkproject.regularcustomermanagement.presentation.ui.createCustomer.BasicInfo.BasicInfoScreen
+import com.dkproject.regularcustomermanagement.presentation.utils.Constants.CREATECUSTOMERSTEPS
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreateCustomerScreen(
+    uiState: CreateCustomerUiState,
+    onMoveStep: (CreateCustomerStep) -> Unit = {},
+    popBackStack: () -> Unit = {},
+    updateBasicInfo: (BasicInfo) -> Unit = {},
+) {
+    val currentStep = uiState.currentStep
+    val progressValue by animateFloatAsState(
+        targetValue = uiState.currentStep.progress,
+        label = "progress"
+    )
+    BackHandler {
+        when (currentStep) {
+            CreateCustomerStep.BASIC -> popBackStack()
+            CreateCustomerStep.AFFILIATION -> onMoveStep(CreateCustomerStep.BASIC)
+            CreateCustomerStep.MEMO -> onMoveStep(CreateCustomerStep.AFFILIATION)
+        }
+    }
+    Column(modifier = Modifier.fillMaxSize()) {
+        CenterAlignedTopAppBar(title = {
+            Text(
+                stringResource(R.string.addcustomer),
+                fontWeight = FontWeight.Bold
+            )
+        },
+            navigationIcon = {
+                when (currentStep) {
+                    CreateCustomerStep.BASIC -> {
+                        IconButton(onClick = {}) {
+                            Icon(Icons.Default.Close, null)
+                        }
+                    }
+                    else -> {
+                        IconButton(onClick = {
+                            if (currentStep == CreateCustomerStep.AFFILIATION) onMoveStep(CreateCustomerStep.BASIC)
+                            else onMoveStep(CreateCustomerStep.AFFILIATION)
+                        }) {
+                            Icon(Icons.AutoMirrored.Default.ArrowBack, null)
+                        }
+                    }
+                }
+            }
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp, vertical = 16.dp)
+        ) {
+            Row {
+                CREATECUSTOMERSTEPS.forEachIndexed { index, step ->
+                    AnimatedStepText(
+                        text = stringResource(step.label),
+                        isSelected = currentStep == step,
+                    )
+                    if (index != CREATECUSTOMERSTEPS.lastIndex)
+                        Spacer(modifier = Modifier.weight(1f))
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 12.dp)
+            ) {
+                LinearProgressIndicator(modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 14.dp),
+                    progress = { progressValue })
+                Row(verticalAlignment = Alignment.Top) {
+                    CREATECUSTOMERSTEPS.forEachIndexed { index, step ->
+                        val iconRes = when {
+                            index < CREATECUSTOMERSTEPS.indexOf(currentStep) -> R.drawable.checkcircle       // 완료
+                            index == CREATECUSTOMERSTEPS.indexOf(currentStep) -> R.drawable.ingcircle         // 현재 진행 중
+                            else -> R.drawable.noncheckcircle                     // 아직 도달 X
+                        }
+                        Crossfade(targetState = iconRes, label = "StepIconCrossfade") { icon ->
+                            Image(painter = painterResource(id = icon), contentDescription = null)
+                        }
+                        if (index != CREATECUSTOMERSTEPS.lastIndex)
+                            Spacer(modifier = Modifier.weight(1f))
+                    }
+                }
+            }
+            AnimatedContent(targetState = currentStep, label = "") { step ->
+                when (step) {
+                    CreateCustomerStep.BASIC -> {
+                        BasicInfoScreen(modifier = Modifier, onNextStep = { basicInfo ->
+                            updateBasicInfo(basicInfo)
+                            onMoveStep(CreateCustomerStep.AFFILIATION)
+                        })
+                    }
+                    CreateCustomerStep.AFFILIATION -> {
+                        AffiliationInfoScreen()
+                    }
+                    CreateCustomerStep.MEMO -> {}
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun CreateCustomerSreenPreview() {
+    RegularCustomerManagementTheme {
+        CreateCustomerScreen(uiState = CreateCustomerUiState())
+    }
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/CreateCustomerScreen.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/CreateCustomerScreen.kt
@@ -93,7 +93,8 @@ fun CreateCustomerScreen(
                         IconButton(onClick = {
                             if (currentStep == CreateCustomerStep.AFFILIATION) onMoveStep(CreateCustomerStep.BASIC)
                             else onMoveStep(CreateCustomerStep.AFFILIATION)
-                        }) {
+                        },
+                            enabled = !uiState.loading) {
                             Icon(Icons.AutoMirrored.Default.ArrowBack, null)
                         }
                     }

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/CreateCustomerScreen.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/CreateCustomerScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -48,6 +49,7 @@ import com.dkproject.regularcustomermanagement.presentation.model.CreateCustomer
 import com.dkproject.regularcustomermanagement.presentation.theme.RegularCustomerManagementTheme
 import com.dkproject.regularcustomermanagement.presentation.ui.createCustomer.AffiliationInfo.AffiliationInfoScreen
 import com.dkproject.regularcustomermanagement.presentation.ui.createCustomer.BasicInfo.BasicInfoScreen
+import com.dkproject.regularcustomermanagement.presentation.ui.createCustomer.Memo.MemoScreen
 import com.dkproject.regularcustomermanagement.presentation.utils.Constants.CREATECUSTOMERSTEPS
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -57,6 +59,9 @@ fun CreateCustomerScreen(
     onMoveStep: (CreateCustomerStep) -> Unit = {},
     popBackStack: () -> Unit = {},
     updateBasicInfo: (BasicInfo) -> Unit = {},
+    updateAffiliationAndTags: (String, List<String>) -> Unit,
+    updateStarAndMemo: (Boolean, List<String>) -> Unit = { _, _ -> },
+    onCompleted: () -> Unit = {}
 ) {
     val currentStep = uiState.currentStep
     val progressValue by animateFloatAsState(
@@ -91,6 +96,13 @@ fun CreateCustomerScreen(
                         }) {
                             Icon(Icons.AutoMirrored.Default.ArrowBack, null)
                         }
+                    }
+                }
+            },
+            actions = {
+                AnimatedVisibility(currentStep == CreateCustomerStep.MEMO) {
+                    TextButton(onCompleted) {
+                        Text(stringResource(R.string.complete))
                     }
                 }
             }
@@ -143,9 +155,17 @@ fun CreateCustomerScreen(
                         })
                     }
                     CreateCustomerStep.AFFILIATION -> {
-                        AffiliationInfoScreen()
+                        AffiliationInfoScreen(onNextStep = { affiliationName, tags ->
+                            updateAffiliationAndTags(affiliationName,tags)
+                            onMoveStep(CreateCustomerStep.MEMO)
+                        })
                     }
-                    CreateCustomerStep.MEMO -> {}
+                    CreateCustomerStep.MEMO -> {
+                        MemoScreen(updateStarAndMemo = { star, memo ->
+                            updateStarAndMemo(star, memo)
+                            onCompleted()
+                        })
+                    }
                 }
             }
         }
@@ -156,6 +176,6 @@ fun CreateCustomerScreen(
 @Preview(showBackground = true)
 private fun CreateCustomerSreenPreview() {
     RegularCustomerManagementTheme {
-        CreateCustomerScreen(uiState = CreateCustomerUiState())
+        CreateCustomerScreen(uiState = CreateCustomerUiState(), updateAffiliationAndTags = {_, _ ->})
     }
 }

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/CreateCustomerViewModel.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/CreateCustomerViewModel.kt
@@ -1,19 +1,24 @@
 package com.dkproject.regularcustomermanagement.presentation.ui.createCustomer
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.dkproject.regularcustomermanagement.domain.model.Customer
+import com.dkproject.regularcustomermanagement.domain.usecase.AddCustomerUseCase
 import com.dkproject.regularcustomermanagement.presentation.model.BasicInfo
 import com.dkproject.regularcustomermanagement.presentation.model.CreateCustomerStep
 import com.dkproject.regularcustomermanagement.presentation.navigation.TabScreen
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class CreateCustomerViewModel @Inject constructor(
-
+    private val addCustomerUseCase: AddCustomerUseCase
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(CreateCustomerUiState())
     val uiState = _uiState.asStateFlow()
@@ -32,6 +37,40 @@ class CreateCustomerViewModel @Inject constructor(
                     carNumber = basicInfo.carNumber
                 )
             )
+        }
+    }
+
+    fun updateAffiliationAndTags(affiliationName: String, tags: List<String>) {
+        _uiState.update {
+            it.copy(
+                customer = it.customer.copy(
+                    affiliation = affiliationName,
+                    tags = tags
+                )
+            )
+        }
+    }
+
+    fun updateStarAndMemo(isStar: Boolean, memo: List<String>) {
+        _uiState.update {
+            it.copy(
+                customer = it.customer.copy(
+                    isStar = isStar,
+                    memoList = memo
+                )
+            )
+        }
+    }
+
+    fun addCustomer() {
+        viewModelScope.launch(context = Dispatchers.IO) {
+            addCustomerUseCase(customer = uiState.value.customer)
+                .onFailure {
+                    Log.d("dk", "fail")
+                }
+                .onSuccess {
+                    Log.d("dk", "success")
+                }
         }
     }
 }

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/CreateCustomerViewModel.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/CreateCustomerViewModel.kt
@@ -3,6 +3,7 @@ package com.dkproject.regularcustomermanagement.presentation.ui.createCustomer
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.dkproject.regularcustomermanagement.R
 import com.dkproject.regularcustomermanagement.domain.model.Customer
 import com.dkproject.regularcustomermanagement.domain.usecase.AddCustomerUseCase
 import com.dkproject.regularcustomermanagement.presentation.model.BaseUiEvent
@@ -10,6 +11,7 @@ import com.dkproject.regularcustomermanagement.presentation.model.BasicInfo
 import com.dkproject.regularcustomermanagement.presentation.model.CreateCustomerStep
 import com.dkproject.regularcustomermanagement.presentation.navigation.TabScreen
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,7 +23,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class CreateCustomerViewModel @Inject constructor(
-    private val addCustomerUseCase: AddCustomerUseCase
+    private val addCustomerUseCase: AddCustomerUseCase,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(CreateCustomerUiState())
     val uiState = _uiState.asStateFlow()
@@ -74,10 +76,11 @@ class CreateCustomerViewModel @Inject constructor(
             addCustomerUseCase(customer = uiState.value.customer)
                 .onFailure {
                     _uiState.update { it.copy(loading = false) }
-                    Log.d("dk", "fail")
+                    _uiEvent.emit(BaseUiEvent.ShowToast(R.string.failaddcustomer))
                 }
                 .onSuccess {
-                    Log.d("dk", "success")
+                    _uiState.update { it.copy(loading = false) }
+                    _uiEvent.emit(BaseUiEvent.PopBackStack)
                 }
         }
     }

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/CreateCustomerViewModel.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/CreateCustomerViewModel.kt
@@ -1,0 +1,42 @@
+package com.dkproject.regularcustomermanagement.presentation.ui.createCustomer
+
+import androidx.lifecycle.ViewModel
+import com.dkproject.regularcustomermanagement.domain.model.Customer
+import com.dkproject.regularcustomermanagement.presentation.model.BasicInfo
+import com.dkproject.regularcustomermanagement.presentation.model.CreateCustomerStep
+import com.dkproject.regularcustomermanagement.presentation.navigation.TabScreen
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class CreateCustomerViewModel @Inject constructor(
+
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(CreateCustomerUiState())
+    val uiState = _uiState.asStateFlow()
+
+    fun updateCurrentStep(step: CreateCustomerStep) {
+        _uiState.update { it.copy(currentStep = step) }
+    }
+
+    fun updateBasicInfo(basicInfo: BasicInfo) {
+        _uiState.update {
+            it.copy(
+                customer = it.customer.copy(
+                    name = basicInfo.name,
+                    phoneNumber = basicInfo.phoneNumber,
+                    nickName = basicInfo.nickName,
+                    carNumber = basicInfo.carNumber
+                )
+            )
+        }
+    }
+}
+
+data class CreateCustomerUiState(
+    val currentStep: CreateCustomerStep = CreateCustomerStep.BASIC,
+    val customer: Customer = Customer()
+)

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/Memo/MemoScreen.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/Memo/MemoScreen.kt
@@ -1,0 +1,148 @@
+package com.dkproject.regularcustomermanagement.presentation.ui.createCustomer.Memo
+
+import android.annotation.SuppressLint
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.dkproject.regularcustomermanagement.R
+import com.dkproject.regularcustomermanagement.presentation.Component.Button.BasicButton
+import com.dkproject.regularcustomermanagement.presentation.Component.TexetField.DefaultTextField
+import com.dkproject.regularcustomermanagement.presentation.Component.Text.MemoTextBox
+import com.dkproject.regularcustomermanagement.presentation.theme.RegularCustomerManagementTheme
+
+@SuppressLint("UnusedBoxWithConstraintsScope")
+@Composable
+fun MemoScreen(
+    viewModel: MemoViewModel = hiltViewModel(),
+    modifier: Modifier = Modifier,
+    updateStarAndMemo: (Boolean, List<String>) -> Unit = {_, _ ->}
+) {
+
+    var memoString by rememberSaveable { mutableStateOf("") }
+    val interactionSource = remember { MutableInteractionSource() }
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val maxHeight = maxHeight
+        Column {
+            Column(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(dimensionResource(R.dimen.padding_small)))
+                    .heightIn(min = 0.dp, max = maxHeight * 0.75f)
+                    .background(MaterialTheme.colorScheme.onSecondary)
+                    .padding(dimensionResource(R.dimen.padding_medium))
+                    .verticalScroll(rememberScrollState())
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(text = stringResource(R.string.favorites), fontWeight = FontWeight.Bold)
+                    Spacer(modifier = Modifier.weight(1f))
+                    Switch(
+                        checked = uiState.isStar,
+                        onCheckedChange = viewModel::updateIsStar
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.memo), fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(top = dimensionResource(R.dimen.padding_small))
+                )
+
+                Row(
+                    verticalAlignment = Alignment.Top,
+                    modifier = Modifier.padding(vertical = dimensionResource(R.dimen.padding_small))
+                ) {
+                    DefaultTextField(
+                        value = memoString,
+                        onValueChange = { memoString = it },
+                        modifier = Modifier
+                            .weight(3f)
+                            .heightIn(
+                                min = dimensionResource(R.dimen.textfield_min),
+                                max = dimensionResource(R.dimen.textfield_max)
+                            ),
+                        interactionSource = interactionSource,
+                        placeholder = stringResource(R.string.memoplaceholder)
+                    )
+                    Spacer(modifier = Modifier.padding(horizontal = dimensionResource(R.dimen.padding_six)))
+                    BasicButton(
+                        modifier = Modifier.weight(1f),
+                        title = stringResource(R.string.add),
+                        onClick = {
+                            viewModel.pluseMemo(memoString)
+                            memoString = ""
+                        },
+                    )
+                }
+                AnimatedVisibility(uiState.memoList.isNotEmpty()) {
+                    Column(verticalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.padding_six))) {
+                        uiState.memoList.forEach { memo ->
+                            MemoTextBox(
+                                modifier = Modifier.fillMaxWidth(),
+                                value = memo,
+                                isDelete = true,
+                                onDeleteClick = { viewModel.removeMemo(memo) }
+                            )
+                        }
+                    }
+                }
+                if (uiState.memoList.isEmpty()) {
+                    Text(
+                        text = "메모 사항이 존재하지 않습니다!",
+                        modifier = Modifier.padding(vertical = dimensionResource(R.dimen.padding_four)),
+                        style = MaterialTheme.typography.labelMedium
+                    )
+                }
+            }
+            BasicButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = dimensionResource(R.dimen.padding_medium)),
+                title = stringResource(R.string.complete),
+                onClick = {
+                    updateStarAndMemo(uiState.isStar, uiState.memoList)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun MemoScreenPreview() {
+    RegularCustomerManagementTheme {
+        Column(modifier = Modifier.fillMaxSize()) {
+            MemoScreen()
+        }
+    }
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/Memo/MemoScreen.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/Memo/MemoScreen.kt
@@ -48,6 +48,7 @@ import com.dkproject.regularcustomermanagement.presentation.theme.RegularCustome
 fun MemoScreen(
     viewModel: MemoViewModel = hiltViewModel(),
     modifier: Modifier = Modifier,
+    loading: Boolean = false,
     updateStarAndMemo: (Boolean, List<String>) -> Unit = {_, _ ->}
 ) {
 
@@ -129,6 +130,8 @@ fun MemoScreen(
                     .fillMaxWidth()
                     .padding(vertical = dimensionResource(R.dimen.padding_medium)),
                 title = stringResource(R.string.complete),
+                enabled = !loading,
+                loading = loading,
                 onClick = {
                     updateStarAndMemo(uiState.isStar, uiState.memoList)
                 }

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/Memo/MemoViewModel.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/createCustomer/Memo/MemoViewModel.kt
@@ -1,0 +1,33 @@
+package com.dkproject.regularcustomermanagement.presentation.ui.createCustomer.Memo
+
+import android.text.BoringLayout
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class MemoViewModel @Inject constructor(
+
+): ViewModel() {
+    private val _uiState = MutableStateFlow(MemoUiState())
+    val uiState = _uiState.asStateFlow()
+
+    fun updateIsStar(isStar: Boolean) {
+        _uiState.value = _uiState.value.copy(isStar = isStar)
+    }
+
+    fun pluseMemo(memo: String) {
+        _uiState.value = _uiState.value.copy(memoList = _uiState.value.memoList + memo)
+    }
+
+    fun removeMemo(memo: String) {
+        _uiState.value = _uiState.value.copy(memoList = _uiState.value.memoList - memo)
+    }
+}
+
+data class MemoUiState(
+    val isStar: Boolean = false,
+    val memoList: List<String> = emptyList()
+)

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/customer/CustomerScreen.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/ui/customer/CustomerScreen.kt
@@ -1,0 +1,15 @@
+package com.dkproject.regularcustomermanagement.presentation.ui.customer
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun CustomerScreen(
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        Text("this is customerScreen")
+    }
+}

--- a/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/utils/Constants.kt
+++ b/RegularCustomerManagement/app/src/main/java/com/dkproject/regularcustomermanagement/presentation/utils/Constants.kt
@@ -1,0 +1,12 @@
+package com.dkproject.regularcustomermanagement.presentation.utils
+
+import com.dkproject.regularcustomermanagement.presentation.model.CreateCustomerStep
+
+object Constants {
+    val CREATECUSTOMERSTEPS = listOf(
+        CreateCustomerStep.BASIC,
+        CreateCustomerStep.AFFILIATION,
+        CreateCustomerStep.MEMO
+    )
+    val MAX_CUSTOMER_NAME_LENGTH = 15
+}

--- a/RegularCustomerManagement/app/src/main/res/drawable/checkcircle.xml
+++ b/RegularCustomerManagement/app/src/main/res/drawable/checkcircle.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="33dp"
+    android:height="33dp"
+    android:viewportWidth="33"
+    android:viewportHeight="33">
+  <path
+      android:pathData="M16.5,16.5m-16.5,0a16.5,16.5 0,1 1,33 0a16.5,16.5 0,1 1,-33 0"
+      android:fillColor="#0A5AE3"/>
+  <path
+      android:pathData="M14.55,23L8.85,17.3L10.275,15.875L14.55,20.15L23.725,10.975L25.15,12.4L14.55,23Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/RegularCustomerManagement/app/src/main/res/drawable/ingcircle.xml
+++ b/RegularCustomerManagement/app/src/main/res/drawable/ingcircle.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="33dp"
+    android:height="33dp"
+    android:viewportWidth="33"
+    android:viewportHeight="33">
+  <path
+      android:pathData="M16.5,16.5m-16.5,0a16.5,16.5 0,1 1,33 0a16.5,16.5 0,1 1,-33 0"
+      android:fillColor="#0A5AE3"/>
+</vector>

--- a/RegularCustomerManagement/app/src/main/res/drawable/noncheckcircle.xml
+++ b/RegularCustomerManagement/app/src/main/res/drawable/noncheckcircle.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="33dp"
+    android:height="33dp"
+    android:viewportWidth="33"
+    android:viewportHeight="33">
+  <path
+      android:pathData="M16.5,16.5m-16.5,0a16.5,16.5 0,1 1,33 0a16.5,16.5 0,1 1,-33 0"
+      android:fillColor="#E1E3E8"/>
+</vector>

--- a/RegularCustomerManagement/app/src/main/res/values-ja/strings.xml
+++ b/RegularCustomerManagement/app/src/main/res/values-ja/strings.xml
@@ -24,4 +24,5 @@
     <string name="maxtag">タグの最大数は8個です</string>
     <string name="favorites">お気に入り</string>
     <string name="memoplaceholder">" 顧客関連のメモを入力してください"</string>
+    <string name="failaddcustomer">고객 추가에 실패하였습니다.</string>
 </resources>

--- a/RegularCustomerManagement/app/src/main/res/values-ja/strings.xml
+++ b/RegularCustomerManagement/app/src/main/res/values-ja/strings.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">RegularCustomerManagement</string>
+    <string name="home">ホーム</string>
+    <string name="customer">" 顧客"</string>
+    <string name="handover">引き継ぎ</string>
+    <string name="addcustomer">"顧客を追加 "</string>
+    <string name="basicinfo">"基本情報 "</string>
+    <string name="affiliationtag">"所属とタグ "</string>
+    <string name="memo">メモ</string>
+    <string name="name">名前 *</string>
+    <string name="phonenumber">携帯電話番号</string>
+    <string name="nickname">ニックネーム</string>
+    <string name="carnumber">"車両番号 "</string>
+    <string name="customername">" 顧客名 "</string>
+    <string name="maxnamelength">名前は ％d 文字でなければなりません。</string>
+    <string name="phoneplaceholder">01012341234</string>
+    <string name="back">戻る</string>
+    <string name="next">次</string>
+    <string name="complete">完了</string>
+    <string name="independent">"無所属 "</string>
+    <string name="tag">タグ</string>
+    <string name="add">追加</string>
+    <string name="maxtag">タグの最大数は8個です</string>
+</resources>

--- a/RegularCustomerManagement/app/src/main/res/values-ja/strings.xml
+++ b/RegularCustomerManagement/app/src/main/res/values-ja/strings.xml
@@ -22,4 +22,6 @@
     <string name="tag">タグ</string>
     <string name="add">追加</string>
     <string name="maxtag">タグの最大数は8個です</string>
+    <string name="favorites">お気に入り</string>
+    <string name="memoplaceholder">" 顧客関連のメモを入力してください"</string>
 </resources>

--- a/RegularCustomerManagement/app/src/main/res/values-ko/strings.xml
+++ b/RegularCustomerManagement/app/src/main/res/values-ko/strings.xml
@@ -24,4 +24,5 @@
     <string name="maxtag">태그의 최대 수는 8개입니다</string>
     <string name="favorites">즐겨찾기</string>
     <string name="memoplaceholder">고객 관련 메모를 입력해 주세요</string>
+    <string name="failaddcustomer">顧客を追加できませんでした</string>
 </resources>

--- a/RegularCustomerManagement/app/src/main/res/values-ko/strings.xml
+++ b/RegularCustomerManagement/app/src/main/res/values-ko/strings.xml
@@ -22,4 +22,6 @@
     <string name="tag">태그</string>
     <string name="add">추가</string>
     <string name="maxtag">태그의 최대 수는 8개입니다</string>
+    <string name="favorites">즐겨찾기</string>
+    <string name="memoplaceholder">고객 관련 메모를 입력해 주세요</string>
 </resources>

--- a/RegularCustomerManagement/app/src/main/res/values-ko/strings.xml
+++ b/RegularCustomerManagement/app/src/main/res/values-ko/strings.xml
@@ -4,4 +4,22 @@
     <string name="home">홈</string>
     <string name="customer">고객</string>
     <string name="handover">인수인계</string>
+    <string name="addcustomer">고객 추가</string>
+    <string name="basicinfo">기본 정보</string>
+    <string name="affiliationtag">소속</string>
+    <string name="memo">메모사항</string>
+    <string name="name">이름 *</string>
+    <string name="phonenumber">휴대폰 번호</string>
+    <string name="nickname">닉네임</string>
+    <string name="carnumber">차량번호</string>
+    <string name="customername">고객 이름</string>
+    <string name="maxnamelength">이름은 %d자 이하여야 합니다.</string>
+    <string name="phoneplaceholder">01012341234</string>
+    <string name="back">이전</string>
+    <string name="next">다음</string>
+    <string name="complete">완료</string>
+    <string name="independent">무소속</string>
+    <string name="tag">태그</string>
+    <string name="add">추가</string>
+    <string name="maxtag">태그의 최대 수는 8개입니다</string>
 </resources>

--- a/RegularCustomerManagement/app/src/main/res/values/dimens.xml
+++ b/RegularCustomerManagement/app/src/main/res/values/dimens.xml
@@ -6,6 +6,8 @@
     <dimen name="padding_small">12dp</dimen>
     <dimen name="padding_medium">18dp</dimen>
     <dimen name="padding_large">24dp</dimen>
+    <dimen name="textfield_min">160dp</dimen>
+    <dimen name="textfield_max">220dp</dimen>
 
 
 </resources>

--- a/RegularCustomerManagement/app/src/main/res/values/dimens.xml
+++ b/RegularCustomerManagement/app/src/main/res/values/dimens.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="padding_four">4dp</dimen>
+    <dimen name="padding_six">6dp</dimen>
+    <dimen name="padding_eight">8dp</dimen>
+    <dimen name="padding_small">12dp</dimen>
+    <dimen name="padding_medium">18dp</dimen>
+    <dimen name="padding_large">24dp</dimen>
+
+
+</resources>

--- a/RegularCustomerManagement/app/src/main/res/values/strings.xml
+++ b/RegularCustomerManagement/app/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
     <string name="maxtag">The maximum number of tags is 8</string>
     <string name="favorites">Favorites</string>
     <string name="memoplaceholder">Please enter a customer-related note</string>
+    <string name="failaddcustomer">Failed to add customer.</string>
 </resources>

--- a/RegularCustomerManagement/app/src/main/res/values/strings.xml
+++ b/RegularCustomerManagement/app/src/main/res/values/strings.xml
@@ -3,4 +3,22 @@
     <string name="home">Home</string>
     <string name="customer">Customer</string>
     <string name="handover">Hand Over</string>
+    <string name="addcustomer">Add Customer</string>
+    <string name="basicinfo">Basic</string>
+    <string name="affiliationtag">Affiliations</string>
+    <string name="memo">Notes</string>
+    <string name="name">Name *</string>
+    <string name="phonenumber">PhoneNumber</string>
+    <string name="nickname">Nickname</string>
+    <string name="carnumber">Car Number</string>
+    <string name="customername">Customer Name</string>
+    <string name="maxnamelength">"Name must be %d characters or less. "</string>
+    <string name="phoneplaceholder">01012341234</string>
+    <string name="back">Back</string>
+    <string name="next">Next</string>
+    <string name="complete">Complete</string>
+    <string name="independent">Independent</string>
+    <string name="tag">Tag</string>
+    <string name="add">Add</string>
+    <string name="maxtag">The maximum number of tags is 8</string>
 </resources>

--- a/RegularCustomerManagement/app/src/main/res/values/strings.xml
+++ b/RegularCustomerManagement/app/src/main/res/values/strings.xml
@@ -21,4 +21,6 @@
     <string name="tag">Tag</string>
     <string name="add">Add</string>
     <string name="maxtag">The maximum number of tags is 8</string>
+    <string name="favorites">Favorites</string>
+    <string name="memoplaceholder">Please enter a customer-related note</string>
 </resources>


### PR DESCRIPTION
## [Feature] 고객 생성 화면 3단계 분리 및 단계별 뷰모델 도입
<img width="239" alt="image" src="https://github.com/user-attachments/assets/099b2b0d-b407-40f3-9e0d-2d328d8166fd" />

### 작업 내용
- 고객 생성(CreateCustomer) 프로세스를 아래 3단계로 분리:
  - 기본 정보 입력 (BasicInfo)
  - 소속 및 태그 입력 (AffiliationInfo)
  - 메모 입력 및 즐겨찾기 설정 (Memo)

- 각 단계별로 독립된 화면 및 ViewModel 구성
  - BasicInfoScreen.kt + BasicInfoViewModel.kt
  - AffiliationInfoScreen.kt + AffiliationViewModel.kt
  - MemoScreen.kt + MemoViewModel.kt

- 각 단계의 데이터는 CreateCustomerViewModel을 통해 통합 관리
  - 단계 이동 시 각 뷰모델에서 CreateCustomerViewModel로 상태 전달
  - 마지막 단계에서 전체 Customer 데이터 생성

### 이유
- 고객 생성 과정의 복잡도를 줄이기 위해 단계별로 로직 분리
- 향후 각 단계별 기능 확장 및 유지보수 편의성 고려
- 단일 ViewModel의 책임 과다 방지 (Single Responsibility Principle)

## Domain, Data Layer
- `AddCustomerUseCase` 작성 -> Repository 호출
- Repository -> DataSource의 dao 호출
```kotlin
// RepositoryImpl
 override suspend fun addCustomer(customer: Customer): Result<Unit> = runCatching {
        customerDataSource.addCustomer(customer.toEntity())
    }
```
- Result<Unit> 반환

## 스크린샷
| **Compact**  |  **Medium**  |  **Expanded** |
|--------------|--------------|--------------|
|![Screenshot_1744953790](https://github.com/user-attachments/assets/edeb3932-4ee1-4855-82ad-5f06be0047eb)  |![Screenshot_1744953830](https://github.com/user-attachments/assets/b403a350-9007-45cd-aebd-ef5587116c1c)| ![Screenshot_1744953852](https://github.com/user-attachments/assets/473f91ba-edbc-4c97-b688-775682c1ebe4)

